### PR TITLE
Add blog posts, modern card design, and teal color scheme

### DIFF
--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -17,7 +17,7 @@ if (!TagProp && Astro.props.slug) {
   TagProp && (
     <Link
       href={`/tags/${TagProp.id}`}
-      class="mr-3 text-sm font-medium uppercase text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+      class="mr-2 inline-block rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700 transition-all duration-200 hover:bg-primary-100 hover:text-primary-700 hover:scale-105 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-primary-900/30 dark:hover:text-primary-300"
     >
       {TagProp.data.name}
     </Link>

--- a/src/content/blog/2026-bridging-research-and-industry.mdx
+++ b/src/content/blog/2026-bridging-research-and-industry.mdx
@@ -1,0 +1,12 @@
+---
+title: 'Bridging Cutting-Edge Research and Social Implementation: A Border-Crosser Implementing World-Class Academic Knowledge in Society'
+date: 2026-03-01
+summary: 'Interview article about joining CADDi as Senior Research Engineer, discussing the journey between academia and industry, how LLMs democratize research participation, 3D scaling law breakthroughs in 2025, and building competitive advantages in manufacturing through academic-industry collaboration.'
+tags: ['research', 'career', 'manufacturing', 'computer-vision', 'machine-learning']
+draft: false
+isExternal: true
+externalLinks:
+  - platform: 'note'
+    url: 'https://caddiinc.com/n/n6844cf3c7609'
+    language: 'ja'
+---

--- a/src/content/blog/2026-caddi-manufacturing-ai-research.mdx
+++ b/src/content/blog/2026-caddi-manufacturing-ai-research.mdx
@@ -1,0 +1,12 @@
+---
+title: 'Manufacturing × AI at the Forefront: Where CADDi Research Challenges Meet Current CV and AI'
+date: 2026-03-10
+summary: 'Discusses CADDi research initiatives focusing on VLM language bias affecting spatial reasoning, precise 3D geometry recognition, multimodal data alignment, and manufacturable 3D generation, highlighting intersections between cutting-edge CV research and real manufacturing challenges.'
+tags: ['research', 'computer-vision', 'machine-learning', 'manufacturing', '3d-generation']
+draft: false
+isExternal: true
+externalLinks:
+  - platform: 'hatena'
+    url: 'https://caddi.tech/2026/03/10/110057'
+    language: 'ja'
+---

--- a/src/content/tags/3d-generation.mdx
+++ b/src/content/tags/3d-generation.mdx
@@ -1,0 +1,4 @@
+---
+name: 3D Generation
+description: 3D content generation and modeling
+---

--- a/src/content/tags/career.mdx
+++ b/src/content/tags/career.mdx
@@ -1,0 +1,4 @@
+---
+name: Career
+description: Career development and professional growth
+---

--- a/src/content/tags/machine-learning.mdx
+++ b/src/content/tags/machine-learning.mdx
@@ -1,0 +1,4 @@
+---
+name: Machine Learning
+description: Machine learning and AI topics
+---

--- a/src/content/tags/manufacturing.mdx
+++ b/src/content/tags/manufacturing.mdx
@@ -1,0 +1,4 @@
+---
+name: Manufacturing
+description: Manufacturing industry and production topics
+---

--- a/src/layouts/ListWithTagsLayout.astro
+++ b/src/layouts/ListWithTagsLayout.astro
@@ -96,36 +96,39 @@ const isBlogPage = Astro.url.pathname.startsWith('/blog')
         </div>
       </div>
       <div>
-        <ul>
+        <ul class="space-y-6">
           {
             page.data.map(
               ({ id, data: { date, title, summary, tags, isExternal, externalLinks } }) => (
-                <li class="py-5">
-                  <article class="space-y-2 flex flex-col xl:space-y-0">
+                <li class="group">
+                  <article class="relative rounded-lg border border-gray-200 bg-white p-6 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:hover:shadow-gray-900/50">
                     <dl>
                       <dt class="sr-only">{t('layouts.listWithTagsLayout.publishedAt')}</dt>
-                      <dd class="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
+                      <dd class="text-sm font-medium leading-6 text-gray-500 dark:text-gray-400">
                         <FormattedDate date={date} />
                       </dd>
                     </dl>
-                    <div class="space-y-3">
+                    <div class="mt-3 space-y-3">
                       <div>
-                        <h3 class="text-2xl font-bold leading-8 tracking-tight">
+                        <h3 class="text-2xl font-bold leading-8 tracking-tight transition-colors duration-200">
                           {isExternal ? (
                             <span class="text-gray-900 dark:text-gray-100">{title}</span>
                           ) : (
-                            <Link href={`/blog/${id}`} class="text-gray-900 dark:text-gray-100">
+                            <Link
+                              href={`/blog/${id}`}
+                              class="text-gray-900 hover:text-primary-600 dark:text-gray-100 dark:hover:text-primary-400"
+                            >
                               {title}
                             </Link>
                           )}
                         </h3>
-                        <div class="flex flex-wrap">
+                        <div class="mt-2 flex flex-wrap gap-1.5">
                           {tags.map(({ id }) => (
                             <Tag slug={id} />
                           ))}
                         </div>
                       </div>
-                      <div class="prose max-w-none text-gray-500 dark:text-gray-400">{summary}</div>
+                      <div class="prose max-w-none text-gray-600 dark:text-gray-300">{summary}</div>
                       {isExternal && externalLinks && externalLinks.length > 0 && (
                         <div class="flex flex-wrap gap-2 pt-2">
                           {externalLinks
@@ -138,10 +141,10 @@ const isBlogPage = Astro.url.pathname.startsWith('/blog')
                             .map((link) => (
                               <Link
                                 href={link.url}
-                                class="inline-flex items-center gap-1 rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-800 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                                class="inline-flex items-center gap-1 rounded-md bg-primary-50 px-3 py-1.5 text-sm font-medium text-primary-700 transition-colors duration-200 hover:bg-primary-100 dark:bg-primary-900/30 dark:text-primary-300 dark:hover:bg-primary-900/50"
                               >
                                 <span class="capitalize">{link.platform}</span>
-                                <span class="text-xs text-gray-500 dark:text-gray-400">
+                                <span class="text-xs opacity-75">
                                   ({link.language.toUpperCase()})
                                 </span>
                               </Link>

--- a/src/pages/journey.astro
+++ b/src/pages/journey.astro
@@ -36,7 +36,7 @@ const typeIcons = {
     </div>
 
     <div class="py-8">
-      <div class="space-y-8">
+      <div class="space-y-6">
         {
           sortedPositions.map((position, index) => {
             const isOngoing = !position.data.endDate
@@ -45,7 +45,7 @@ const typeIcons = {
               : `${position.data.startDate} - ${position.data.endDate}`
 
             return (
-              <div class="relative pl-8">
+              <div class="group relative pl-8">
                 {/* Timeline line */}
                 {index < sortedPositions.length - 1 && (
                   <div class="absolute left-2 top-8 h-full w-0.5 bg-gray-300 dark:bg-gray-600" />
@@ -53,43 +53,45 @@ const typeIcons = {
 
                 {/* Timeline dot */}
                 <div
-                  class={`absolute left-0 top-1.5 h-4 w-4 rounded-full ${
+                  class={`absolute left-0 top-1.5 z-10 h-4 w-4 rounded-full transition-all duration-300 ${
                     isOngoing
-                      ? 'bg-primary-500 ring-4 ring-primary-100 dark:ring-primary-900'
-                      : 'bg-gray-400 dark:bg-gray-600'
+                      ? 'bg-primary-500 ring-4 ring-primary-100 group-hover:scale-125 dark:ring-primary-900'
+                      : 'bg-gray-400 group-hover:scale-125 dark:bg-gray-600'
                   }`}
                 />
 
-                <div class="flex flex-col space-y-2 md:flex-row md:space-x-4 md:space-y-0">
-                  <div class="flex-shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400 md:w-48">
-                    <span class="mr-2">
-                      {typeIcons[position.data.type as keyof typeof typeIcons]}
-                    </span>
-                    {dateRange}
+                <article class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:hover:shadow-gray-900/50">
+                  <div class="flex flex-col space-y-2 md:flex-row md:space-x-4 md:space-y-0">
+                    <div class="flex-shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400 md:w-48">
+                      <span class="mr-2">
+                        {typeIcons[position.data.type as keyof typeof typeIcons]}
+                      </span>
+                      {dateRange}
+                    </div>
+                    <div class="flex-1">
+                      <h3 class="text-lg font-semibold text-gray-900 transition-colors duration-200 group-hover:text-primary-600 dark:text-gray-100 dark:group-hover:text-primary-400">
+                        {position.data.title}
+                      </h3>
+                      {position.data.organizationUrl ? (
+                        <Link
+                          href={position.data.organizationUrl}
+                          class="text-gray-700 hover:text-primary-500 dark:text-gray-300 dark:hover:text-primary-400"
+                        >
+                          {position.data.organization}
+                        </Link>
+                      ) : (
+                        <p class="text-gray-700 dark:text-gray-300">{position.data.organization}</p>
+                      )}
+                      {position.data.notes && position.data.notes.length > 0 && (
+                        <ul class="mt-2 list-inside list-disc space-y-1 text-sm text-gray-600 dark:text-gray-400">
+                          {position.data.notes.map((note) => (
+                            <li>{note}</li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
                   </div>
-                  <div class="flex-1">
-                    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                      {position.data.title}
-                    </h3>
-                    {position.data.organizationUrl ? (
-                      <Link
-                        href={position.data.organizationUrl}
-                        class="text-gray-700 hover:text-primary-500 dark:text-gray-300 dark:hover:text-primary-400"
-                      >
-                        {position.data.organization}
-                      </Link>
-                    ) : (
-                      <p class="text-gray-700 dark:text-gray-300">{position.data.organization}</p>
-                    )}
-                    {position.data.notes && position.data.notes.length > 0 && (
-                      <ul class="mt-2 list-inside list-disc space-y-1 text-sm text-gray-600 dark:text-gray-400">
-                        {position.data.notes.map((note) => (
-                          <li>{note}</li>
-                        ))}
-                      </ul>
-                    )}
-                  </div>
-                </div>
+                </article>
               </div>
             )
           })

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -62,33 +62,38 @@ const categoryNames = {
             <h2 class="mb-6 text-2xl font-bold text-gray-900 dark:text-gray-100">
               {categoryNames[category as keyof typeof categoryNames]}
             </h2>
-            <ul class="space-y-6">
+            <ul class="space-y-4">
               {pubs.map((pub) => (
-                <li class="border-l-4 border-primary-500 pl-4">
-                  <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                    {pub.data.title}
-                  </h3>
-                  <p class="mt-1 text-gray-700 dark:text-gray-300">{pub.data.authors}</p>
-                  <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                    {pub.data.venue}, {pub.data.year}
-                  </p>
-                  {pub.data.links && pub.data.links.length > 0 && (
-                    <div class="mt-2 flex flex-wrap gap-2">
-                      {pub.data.links.map((link) => (
-                        <Link
-                          href={link.url}
-                          class="inline-flex items-center rounded bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-800 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-                        >
-                          [{link.type.toUpperCase()}]
-                        </Link>
-                      ))}
+                <li class="group">
+                  <article class="relative overflow-hidden rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:hover:shadow-gray-900/50">
+                    <div class="absolute left-0 top-0 h-full w-1 bg-primary-500 transition-all duration-300 group-hover:w-1.5" />
+                    <div class="pl-3">
+                      <h3 class="text-lg font-semibold text-gray-900 transition-colors duration-200 group-hover:text-primary-600 dark:text-gray-100 dark:group-hover:text-primary-400">
+                        {pub.data.title}
+                      </h3>
+                      <p class="mt-2 text-gray-700 dark:text-gray-300">{pub.data.authors}</p>
+                      <p class="mt-1 text-sm font-medium text-gray-600 dark:text-gray-400">
+                        {pub.data.venue}, {pub.data.year}
+                      </p>
+                      {pub.data.links && pub.data.links.length > 0 && (
+                        <div class="mt-3 flex flex-wrap gap-2">
+                          {pub.data.links.map((link) => (
+                            <Link
+                              href={link.url}
+                              class="inline-flex items-center rounded-md bg-primary-50 px-3 py-1.5 text-xs font-medium text-primary-700 transition-all duration-200 hover:bg-primary-100 hover:scale-105 dark:bg-primary-900/30 dark:text-primary-300 dark:hover:bg-primary-900/50"
+                            >
+                              [{link.type.toUpperCase()}]
+                            </Link>
+                          ))}
+                        </div>
+                      )}
+                      {pub.data.notes && (
+                        <p class="mt-3 text-sm italic text-gray-600 dark:text-gray-400">
+                          {pub.data.notes}
+                        </p>
+                      )}
                     </div>
-                  )}
-                  {pub.data.notes && (
-                    <p class="mt-2 text-sm italic text-gray-500 dark:text-gray-400">
-                      {pub.data.notes}
-                    </p>
-                  )}
+                  </article>
                 </li>
               ))}
             </ul>

--- a/src/pages/service.astro
+++ b/src/pages/service.astro
@@ -69,29 +69,25 @@ const typeIcons = {
               <span class="mr-2">{typeIcons[type as keyof typeof typeIcons]}</span>
               {typeNames[type as keyof typeof typeNames]}
             </h2>
-            <ul class="space-y-6">
+            <ul class="space-y-4">
               {items.map((item) => (
-                <li class="border-l-4 border-primary-500 pl-4">
-                  <div class="flex flex-col space-y-2 md:flex-row md:space-x-4 md:space-y-0">
-                    <div class="flex-shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400 md:w-32">
-                      {item.data.date}
-                    </div>
-                    <div class="flex-1">
-                      <div class="flex items-start justify-between">
+                <li class="group">
+                  <article class="relative overflow-hidden rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:hover:shadow-gray-900/50">
+                    <div class="absolute left-0 top-0 h-full w-1 bg-primary-500 transition-all duration-300 group-hover:w-1.5" />
+                    <div class="pl-3">
+                      <div class="flex flex-col space-y-2 md:flex-row md:space-x-4 md:space-y-0">
+                        <div class="flex-shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400 md:w-32">
+                          {item.data.date}
+                        </div>
                         <div class="flex-1">
-                          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                          <h3 class="text-lg font-semibold text-gray-900 transition-colors duration-200 group-hover:text-primary-600 dark:text-gray-100 dark:group-hover:text-primary-400">
                             {item.data.url ? (
-                              <Link
-                                href={item.data.url}
-                                class="hover:text-primary-500 dark:hover:text-primary-400"
-                              >
-                                {item.data.title}
-                              </Link>
+                              <Link href={item.data.url}>{item.data.title}</Link>
                             ) : (
                               item.data.title
                             )}
                           </h3>
-                          <p class="mt-1 text-gray-700 dark:text-gray-300">
+                          <p class="mt-2 text-gray-700 dark:text-gray-300">
                             <span class="font-medium">{item.data.role}</span> at {item.data.venue}
                           </p>
                           {item.data.description && (
@@ -102,7 +98,7 @@ const typeIcons = {
                         </div>
                       </div>
                     </div>
-                  </div>
+                  </article>
                 </li>
               ))}
             </ul>

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -41,14 +41,15 @@ const typeBadgeColors = {
     </div>
 
     <div class="py-8">
-      <ul class="space-y-6">
+      <ul class="space-y-4">
         {
           sortedTalks.map((talk) => (
-            <li class="border-l-4 border-primary-500 pl-4">
-              <div class="flex items-start justify-between">
-                <div class="flex-1">
-                  <div class="flex items-center gap-2">
-                    <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            <li class="group">
+              <article class="relative overflow-hidden rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:hover:shadow-gray-900/50">
+                <div class="absolute left-0 top-0 h-full w-1 bg-primary-500 transition-all duration-300 group-hover:w-1.5" />
+                <div class="pl-3">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <h3 class="text-lg font-semibold text-gray-900 transition-colors duration-200 group-hover:text-primary-600 dark:text-gray-100 dark:group-hover:text-primary-400">
                       {talk.data.title}
                     </h3>
                     <span
@@ -57,28 +58,32 @@ const typeBadgeColors = {
                       {typeLabels[talk.data.type as keyof typeof typeLabels]}
                     </span>
                   </div>
-                  <p class="mt-1 text-gray-700 dark:text-gray-300">{talk.data.venue}</p>
-                  <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{talk.data.date}</p>
-                  <div class="mt-2 flex flex-wrap gap-2">
-                    {talk.data.slides && (
-                      <Link
-                        href={talk.data.slides}
-                        class="inline-flex items-center rounded bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-800 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-                      >
-                        📊 Slides
-                      </Link>
-                    )}
-                    {talk.data.video && (
-                      <Link
-                        href={talk.data.video}
-                        class="inline-flex items-center rounded bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-800 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-                      >
-                        🎥 Video
-                      </Link>
-                    )}
-                  </div>
+                  <p class="mt-2 text-gray-700 dark:text-gray-300">{talk.data.venue}</p>
+                  <p class="mt-1 text-sm font-medium text-gray-500 dark:text-gray-400">
+                    {talk.data.date}
+                  </p>
+                  {(talk.data.slides || talk.data.video) && (
+                    <div class="mt-3 flex flex-wrap gap-2">
+                      {talk.data.slides && (
+                        <Link
+                          href={talk.data.slides}
+                          class="inline-flex items-center rounded-md bg-primary-50 px-3 py-1.5 text-xs font-medium text-primary-700 transition-all duration-200 hover:bg-primary-100 hover:scale-105 dark:bg-primary-900/30 dark:text-primary-300 dark:hover:bg-primary-900/50"
+                        >
+                          📊 Slides
+                        </Link>
+                      )}
+                      {talk.data.video && (
+                        <Link
+                          href={talk.data.video}
+                          class="inline-flex items-center rounded-md bg-primary-50 px-3 py-1.5 text-xs font-medium text-primary-700 transition-all duration-200 hover:bg-primary-100 hover:scale-105 dark:bg-primary-900/30 dark:text-primary-300 dark:hover:bg-primary-900/50"
+                        >
+                          🎥 Video
+                        </Link>
+                      )}
+                    </div>
+                  )}
                 </div>
-              </div>
+              </article>
             </li>
           ))
         }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,18 +14,18 @@
   --line-height-13: 3.25rem;
   --line-height-14: 3.5rem;
 
-  /* Map custom primary color scale to the default pink palette */
-  --color-primary-50: var(--color-pink-50);
-  --color-primary-100: var(--color-pink-100);
-  --color-primary-200: var(--color-pink-200);
-  --color-primary-300: var(--color-pink-300);
-  --color-primary-400: var(--color-pink-400);
-  --color-primary-500: var(--color-pink-500);
-  --color-primary-600: var(--color-pink-600);
-  --color-primary-700: var(--color-pink-700);
-  --color-primary-800: var(--color-pink-800);
-  --color-primary-900: var(--color-pink-900);
-  --color-primary-950: var(--color-pink-950);
+  /* Map custom primary color scale to the teal palette - RGB(20, 184, 166) = #14b8a6 */
+  --color-primary-50: var(--color-teal-50);
+  --color-primary-100: var(--color-teal-100);
+  --color-primary-200: var(--color-teal-200);
+  --color-primary-300: var(--color-teal-300);
+  --color-primary-400: var(--color-teal-400);
+  --color-primary-500: var(--color-teal-500);
+  --color-primary-600: var(--color-teal-600);
+  --color-primary-700: var(--color-teal-700);
+  --color-primary-800: var(--color-teal-800);
+  --color-primary-900: var(--color-teal-900);
+  --color-primary-950: var(--color-teal-950);
 }
 
 .task-list-item::before {


### PR DESCRIPTION
## Summary
- Add 2 new blog posts about CADDi career journey and research challenges
- Add missing tag definitions for proper tag display
- Implement modern, interactive card-based design across all list pages
- Change primary color scheme from pink to teal

## Changes

### New Content
- ✅ Blog: "Bridging Cutting-Edge Research and Social Implementation" (CADDi career interview)
- ✅ Blog: "Manufacturing × AI at the Forefront" (CADDi research initiatives)
- ✅ Tags: `machine-learning`, `manufacturing`, `3d-generation`, `career`

### Design Improvements
- ✅ Modern card-based layout with borders, shadows, and backgrounds
- ✅ Smooth hover animations (lift effect, shadow expansion)
- ✅ Interactive transitions (300ms duration)
- ✅ Enhanced visual hierarchy and spacing
- ✅ Improved tag component with pill-style design

### Pages Updated
- `/blog` - Card design with hover lift effect
- `/publications` - Card layout with accent bar
- `/talks` - Modern cards with resource buttons
- `/service` - Enhanced organization items
- `/journey` - Timeline with interactive cards

### Color Scheme
- Changed primary color: Pink → Teal
- Teal-500: `#14b8a6` (RGB 20, 184, 166)
- Matches reference site color scheme

## Test plan
- [ ] Check `/blog` page displays new posts correctly
- [ ] Verify all tags are displayed (no missing tag errors)
- [ ] Test hover effects on all list pages
- [ ] Confirm teal color appears consistently across the site
- [ ] Check dark mode compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)