### PR TITLE
Add cover images and venue links to Talks & Presentations

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -104,14 +104,17 @@ const positions = defineCollection({
 
 const talks = defineCollection({
   loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/talks' }),
-  schema: z.object({
-    date: z.string(),
-    title: z.string(),
-    venue: z.string(),
-    type: z.enum(['invited', 'tutorial', 'conference']),
-    slides: z.string().url().optional(),
-    video: z.string().url().optional(),
-  }),
+  schema: ({ image }) =>
+    z.object({
+      date: z.string(),
+      title: z.string(),
+      venue: z.string(),
+      venueUrl: z.string().url().optional(),
+      type: z.enum(['invited', 'tutorial', 'conference']),
+      coverImage: image().optional(),
+      slides: z.string().url().optional(),
+      video: z.string().url().optional(),
+    }),
 })
 
 const awards = defineCollection({

--- a/src/content/talks/2020-adversarial-cover.svg
+++ b/src/content/talks/2020-adversarial-cover.svg
@@ -1,0 +1,38 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad-purple" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9333ea;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#7c3aed;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1280" height="720" fill="url(#grad-purple)"/>
+
+  <!-- Decorative elements -->
+  <circle cx="150" cy="120" r="100" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="1130" cy="600" r="80" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="1050" cy="180" r="60" fill="rgba(255,255,255,0.06)"/>
+  <rect x="950" y="500" width="150" height="150" fill="rgba(255,255,255,0.05)" rx="10" transform="rotate(15 1025 575)"/>
+
+  <!-- Title Area -->
+  <rect x="80" y="220" width="1120" height="280" fill="rgba(255,255,255,0.1)" rx="15"/>
+
+  <!-- Title Text -->
+  <text x="640" y="330" font-family="Arial, sans-serif" font-size="56" font-weight="bold" fill="white" text-anchor="middle">
+    Adversarial Examples
+  </text>
+  <text x="640" y="400" font-family="Arial, sans-serif" font-size="56" font-weight="bold" fill="white" text-anchor="middle">
+    研究動向
+  </text>
+
+  <!-- Subtitle -->
+  <text x="640" y="460" font-family="Arial, sans-serif" font-size="28" fill="rgba(255,255,255,0.9)" text-anchor="middle">
+    Invited Talk at SSII 2020
+  </text>
+
+  <!-- Bottom info -->
+  <text x="640" y="650" font-family="Arial, sans-serif" font-size="20" fill="rgba(255,255,255,0.7)" text-anchor="middle">
+    2020.06
+  </text>
+</svg>

--- a/src/content/talks/2020-adversarial.mdx
+++ b/src/content/talks/2020-adversarial.mdx
@@ -3,4 +3,5 @@ date: '2020.06'
 title: 'Adversarial Examples 研究動向'
 venue: 'Invited Talk, Symposium of Sensing via Image Infomation (SSII), 2020'
 type: 'invited'
+coverImage: './2020-adversarial-cover.svg'
 ---

--- a/src/content/talks/2023-cvpr-tutorial.mdx
+++ b/src/content/talks/2023-cvpr-tutorial.mdx
@@ -3,5 +3,6 @@ date: '2023.07'
 title: 'CVPR 2023 速報'
 venue: 'Tutorial, Meeting on Image Recognition and Understanding (MIRU), 2023'
 type: 'tutorial'
+coverImage: './sample-slide-cover.svg'
 slides: 'https://speakerdeck.com/gatheluck/cvpr-2023-su-bao-ccc-summer-2023-in-mirutiyutoriaru-pei-bu-ban'
 ---

--- a/src/content/talks/2025-cvpaper-cover.svg
+++ b/src/content/talks/2025-cvpaper-cover.svg
@@ -1,0 +1,41 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad-green" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#16a34a;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#15803d;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1280" height="720" fill="url(#grad-green)"/>
+
+  <!-- Decorative elements - representing timeline/journey -->
+  <circle cx="200" cy="150" r="90" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="400" cy="600" r="70" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="800" cy="100" r="60" fill="rgba(255,255,255,0.06)"/>
+  <circle cx="1100" cy="550" r="85" fill="rgba(255,255,255,0.08)"/>
+
+  <!-- Path representing 10 years journey -->
+  <path d="M 100 650 Q 400 200, 700 500 T 1180 200" stroke="rgba(255,255,255,0.15)" stroke-width="8" fill="none" stroke-linecap="round"/>
+
+  <!-- Title Area -->
+  <rect x="80" y="240" width="1120" height="240" fill="rgba(255,255,255,0.12)" rx="15"/>
+
+  <!-- Title Text -->
+  <text x="640" y="330" font-family="Arial, sans-serif" font-size="60" font-weight="bold" fill="white" text-anchor="middle">
+    cvpaper.challenge
+  </text>
+  <text x="640" y="410" font-family="Arial, sans-serif" font-size="54" font-weight="bold" fill="white" text-anchor="middle">
+    10年の軌跡
+  </text>
+
+  <!-- Subtitle -->
+  <text x="640" y="580" font-family="Arial, sans-serif" font-size="28" fill="rgba(255,255,255,0.9)" text-anchor="middle">
+    CCCS 2025
+  </text>
+
+  <!-- Anniversary badge -->
+  <text x="640" y="660" font-family="Arial, sans-serif" font-size="32" font-weight="bold" fill="rgba(255,255,255,0.85)" text-anchor="middle">
+    ⭐ 10th Anniversary ⭐
+  </text>
+</svg>

--- a/src/content/talks/2025-cvpaper-decade.mdx
+++ b/src/content/talks/2025-cvpaper-decade.mdx
@@ -3,5 +3,6 @@ date: '2025.07'
 title: 'cvpaper.challenge 10年の軌跡'
 venue: 'cvpaper.challenge conference summer (CCCS), 2025'
 type: 'conference'
+coverImage: './2025-cvpaper-cover.svg'
 slides: 'https://speakerdeck.com/gatheluck/cvpaper-dot-challenge-a-decade-long-journey'
 ---

--- a/src/content/talks/2026-aspire-workshop-cover.svg
+++ b/src/content/talks/2026-aspire-workshop-cover.svg
@@ -1,0 +1,40 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad-orange" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ea580c;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#c2410c;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1280" height="720" fill="url(#grad-orange)"/>
+
+  <!-- Decorative elements - question marks -->
+  <text x="120" y="150" font-family="Arial, sans-serif" font-size="180" fill="rgba(255,255,255,0.08)" font-weight="bold">?</text>
+  <text x="1050" y="650" font-family="Arial, sans-serif" font-size="120" fill="rgba(255,255,255,0.08)" font-weight="bold">?</text>
+  <circle cx="1100" cy="180" r="70" fill="rgba(255,255,255,0.06)"/>
+
+  <!-- Title Area -->
+  <rect x="80" y="180" width="1120" height="360" fill="rgba(255,255,255,0.12)" rx="15"/>
+
+  <!-- Title Text -->
+  <text x="640" y="270" font-family="Arial, sans-serif" font-size="52" font-weight="bold" fill="white" text-anchor="middle">
+    Who Sets the Questions?
+  </text>
+  <text x="640" y="340" font-family="Arial, sans-serif" font-size="44" font-weight="bold" fill="white" text-anchor="middle">
+    Agenda-Setting Through
+  </text>
+  <text x="640" y="410" font-family="Arial, sans-serif" font-size="44" font-weight="bold" fill="white" text-anchor="middle">
+    Workshops in the Age of AI
+  </text>
+
+  <!-- Subtitle -->
+  <text x="640" y="490" font-family="Arial, sans-serif" font-size="28" fill="rgba(255,255,255,0.9)" text-anchor="middle">
+    ASPIRE Computer Vision Workshop, Tokyo
+  </text>
+
+  <!-- Bottom info -->
+  <text x="640" y="660" font-family="Arial, sans-serif" font-size="24" fill="rgba(255,255,255,0.8)" text-anchor="middle">
+    April 2026
+  </text>
+</svg>

--- a/src/content/talks/2026-aspire-workshop.mdx
+++ b/src/content/talks/2026-aspire-workshop.mdx
@@ -1,0 +1,9 @@
+---
+date: '2026.04'
+title: 'Who Sets the Questions? Agenda-Setting Through Workshops in the Age of AI'
+venue: 'Invited Talk, ASPIRE Computer Vision Workshop, Tokyo'
+venueUrl: 'https://www.aspire.t.u-tokyo.ac.jp/'
+type: 'invited'
+coverImage: './2026-aspire-workshop-cover.svg'
+slides: 'https://speakerdeck.com/gatheluck/who-sets-the-questions-agenda-setting-through-workshops-in-the-age-of-ai'
+---

--- a/src/content/talks/sample-slide-cover.svg
+++ b/src/content/talks/sample-slide-cover.svg
@@ -1,0 +1,34 @@
+<svg width="1280" height="720" viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#14b8a6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#0d9488;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1280" height="720" fill="url(#grad1)"/>
+
+  <!-- Decorative circles -->
+  <circle cx="100" cy="100" r="120" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="1180" cy="620" r="100" fill="rgba(255,255,255,0.08)"/>
+  <circle cx="1100" cy="150" r="80" fill="rgba(255,255,255,0.06)"/>
+
+  <!-- Title Area -->
+  <rect x="80" y="240" width="1120" height="240" fill="rgba(255,255,255,0.1)" rx="15"/>
+
+  <!-- Title Text -->
+  <text x="640" y="340" font-family="Arial, sans-serif" font-size="64" font-weight="bold" fill="white" text-anchor="middle">
+    CVPR 2023 速報
+  </text>
+
+  <!-- Subtitle -->
+  <text x="640" y="410" font-family="Arial, sans-serif" font-size="32" fill="rgba(255,255,255,0.9)" text-anchor="middle">
+    Tutorial at MIRU 2023
+  </text>
+
+  <!-- Bottom info -->
+  <text x="640" y="650" font-family="Arial, sans-serif" font-size="20" fill="rgba(255,255,255,0.7)" text-anchor="middle">
+    16:9 Aspect Ratio | 1280 × 720
+  </text>
+</svg>

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content'
 import RootLayout from '@/layouts/RootLayout.astro'
 import Link from '@/components/Link.astro'
 import { useTranslations } from '@/i18n'
+import { Image } from 'astro:assets'
 
 const t = useTranslations()
 
@@ -45,43 +46,66 @@ const typeBadgeColors = {
         {
           sortedTalks.map((talk) => (
             <li class="group">
-              <article class="relative overflow-hidden rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:hover:shadow-gray-900/50">
+              <article class="relative overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg dark:border-gray-700 dark:bg-gray-800 dark:hover:shadow-gray-900/50">
                 <div class="absolute left-0 top-0 h-full w-1 bg-primary-500 transition-all duration-300 group-hover:w-1.5" />
-                <div class="pl-3">
-                  <div class="flex flex-wrap items-center gap-2">
-                    <h3 class="text-lg font-semibold text-gray-900 transition-colors duration-200 group-hover:text-primary-600 dark:text-gray-100 dark:group-hover:text-primary-400">
-                      {talk.data.title}
-                    </h3>
-                    <span
-                      class={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${typeBadgeColors[talk.data.type as keyof typeof typeBadgeColors]}`}
-                    >
-                      {typeLabels[talk.data.type as keyof typeof typeLabels]}
-                    </span>
-                  </div>
-                  <p class="mt-2 text-gray-700 dark:text-gray-300">{talk.data.venue}</p>
-                  <p class="mt-1 text-sm font-medium text-gray-500 dark:text-gray-400">
-                    {talk.data.date}
-                  </p>
-                  {(talk.data.slides || talk.data.video) && (
-                    <div class="mt-3 flex flex-wrap gap-2">
-                      {talk.data.slides && (
-                        <Link
-                          href={talk.data.slides}
-                          class="inline-flex items-center rounded-md bg-primary-50 px-3 py-1.5 text-xs font-medium text-primary-700 transition-all duration-200 hover:bg-primary-100 hover:scale-105 dark:bg-primary-900/30 dark:text-primary-300 dark:hover:bg-primary-900/50"
-                        >
-                          📊 Slides
-                        </Link>
-                      )}
-                      {talk.data.video && (
-                        <Link
-                          href={talk.data.video}
-                          class="inline-flex items-center rounded-md bg-primary-50 px-3 py-1.5 text-xs font-medium text-primary-700 transition-all duration-200 hover:bg-primary-100 hover:scale-105 dark:bg-primary-900/30 dark:text-primary-300 dark:hover:bg-primary-900/50"
-                        >
-                          🎥 Video
-                        </Link>
-                      )}
+                <div class={`flex ${talk.data.coverImage ? 'flex-col sm:flex-row' : 'p-5 pl-8'}`}>
+                  {talk.data.coverImage && (
+                    <div class="flex-shrink-0 sm:w-64 md:w-80">
+                      <Image
+                        src={talk.data.coverImage}
+                        alt={`Cover for ${talk.data.title}`}
+                        class="h-48 w-full object-cover sm:h-full"
+                        loading="lazy"
+                      />
                     </div>
                   )}
+                  <div class={talk.data.coverImage ? 'flex-1 p-5' : 'flex-1'}>
+                    <div class="flex flex-wrap items-center gap-2">
+                      <h3 class="text-lg font-semibold text-gray-900 transition-colors duration-200 group-hover:text-primary-600 dark:text-gray-100 dark:group-hover:text-primary-400">
+                        {talk.data.title}
+                      </h3>
+                      <span
+                        class={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${typeBadgeColors[talk.data.type as keyof typeof typeBadgeColors]}`}
+                      >
+                        {typeLabels[talk.data.type as keyof typeof typeLabels]}
+                      </span>
+                    </div>
+                    <p class="mt-2 text-gray-700 dark:text-gray-300">
+                      {talk.data.venueUrl ? (
+                        <Link
+                          href={talk.data.venueUrl}
+                          class="hover:text-primary-600 hover:underline dark:hover:text-primary-400"
+                        >
+                          {talk.data.venue}
+                        </Link>
+                      ) : (
+                        talk.data.venue
+                      )}
+                    </p>
+                    <p class="mt-1 text-sm font-medium text-gray-500 dark:text-gray-400">
+                      {talk.data.date}
+                    </p>
+                    {(talk.data.slides || talk.data.video) && (
+                      <div class="mt-3 flex flex-wrap gap-2">
+                        {talk.data.slides && (
+                          <Link
+                            href={talk.data.slides}
+                            class="inline-flex items-center rounded-md bg-primary-50 px-3 py-1.5 text-xs font-medium text-primary-700 transition-all duration-200 hover:bg-primary-100 hover:scale-105 dark:bg-primary-900/30 dark:text-primary-300 dark:hover:bg-primary-900/50"
+                          >
+                            📊 Slides
+                          </Link>
+                        )}
+                        {talk.data.video && (
+                          <Link
+                            href={talk.data.video}
+                            class="inline-flex items-center rounded-md bg-primary-50 px-3 py-1.5 text-xs font-medium text-primary-700 transition-all duration-200 hover:bg-primary-100 hover:scale-105 dark:bg-primary-900/30 dark:text-primary-300 dark:hover:bg-primary-900/50"
+                          >
+                            🎥 Video
+                          </Link>
+                        )}
+                      </div>
+                    )}
+                  </div>
                 </div>
               </article>
             </li>


### PR DESCRIPTION
## Summary
- Add slide cover image display functionality to Talks & Presentations page
- Add optional venue/event links
- Create 16:9 SVG cover images for all talks
- Add new talk from ASPIRE Workshop 2026

## Changes

### New Features
- ✅ **Cover Image Display**: Add `coverImage` field to talks schema
  - Supports 16:9 aspect ratio (standard slide format)
  - Responsive layout: landscape on desktop, portrait on mobile
  - Lazy loading for performance

- ✅ **Venue Links**: Add optional `venueUrl` field
  - Venue name becomes clickable link when URL provided
  - Hover effects for better UX
  - Fully optional - works without URL

### New Content
- ✅ New talk: "Who Sets the Questions? Agenda-Setting Through Workshops in the Age of AI"
  - Date: April 2026
  - Venue: ASPIRE Computer Vision Workshop, Tokyo
  - Type: Invited Talk
  - With cover image and slides link

### Design Improvements
- ✅ Created 16:9 SVG cover images for all talks:
  - 2026 ASPIRE Workshop (Orange gradient with question marks)
  - 2025 cvpaper.challenge (Green gradient with journey path)
  - 2023 CVPR Tutorial (Teal gradient)
  - 2020 Adversarial Examples (Purple gradient with geometric shapes)

### Files Changed
- `src/content.config.ts` - Updated talks schema
- `src/pages/talks.astro` - Enhanced layout with image support
- `src/content/talks/` - Added 4 SVG cover images + 1 new talk

## Usage

### Adding a talk with cover image:
```mdx
---
date: '2026.04'
title: 'Your Talk Title'
venue: 'Conference Name, Location'
venueUrl: 'https://conference-website.com/'  # optional
type: 'invited'
coverImage: './your-slide-cover.jpg'  # 16:9 recommended
slides: 'https://...'
---
```

## Test plan
- [ ] Check `/talks` page displays all cover images correctly
- [ ] Verify responsive layout (desktop: horizontal, mobile: vertical)
- [ ] Test venue links are clickable when provided
- [ ] Confirm talks without images still display correctly
- [ ] Check hover effects on cards and links

🤖 Generated with [Claude Code](https://claude.com/claude-code)