### PR TITLE
feat: update Talks page and add new talks

### DIFF
--- a/src/content/talks/2019-adversarial.mdx
+++ b/src/content/talks/2019-adversarial.mdx
@@ -1,0 +1,8 @@
+---
+date: '2019.09'
+title: 'Adversarial Examples 分野の動向: History and Trends of Dark Arts'
+venue: 'cvpaper.challenge CVPR 2019 網羅的サーベイ報告会 @日立製作所 中央研究所'
+type: 'conference'
+coverImage: './2020-adversarial-cover.svg'
+slides: 'https://www.slideshare.net/cvpaperchallenge/adversarial-examples-173590674'
+---

--- a/src/content/talks/2020-adversarial.mdx
+++ b/src/content/talks/2020-adversarial.mdx
@@ -2,6 +2,7 @@
 date: '2020.06'
 title: 'Adversarial Examples 研究動向'
 venue: 'Invited Talk, Symposium of Sensing via Image Infomation (SSII), 2020'
+venueUrl: 'https://confit.atlas.jp/guide/event/ssii2020/static/invited_interactive#IS2'
 type: 'invited'
 coverImage: './2020-adversarial-cover.svg'
 ---

--- a/src/content/talks/2022-ascender.mdx
+++ b/src/content/talks/2022-ascender.mdx
@@ -1,0 +1,8 @@
+---
+date: '2022.07'
+title: 'Ascender: Accelerator of Scientific Development and Research'
+venue: 'cvpaper.challenge conference summer (CCCS), 2022'
+type: 'conference'
+coverImage: './2020-adversarial-cover.svg'
+slides: 'https://cvpaperchallenge.github.io/Britannica/ascender/ja/'
+---

--- a/src/content/talks/2026-aspire-workshop.mdx
+++ b/src/content/talks/2026-aspire-workshop.mdx
@@ -1,8 +1,8 @@
 ---
 date: '2026.04'
 title: 'Who Sets the Questions? Agenda-Setting Through Workshops in the Age of AI'
-venue: 'Invited Talk, ASPIRE Computer Vision Workshop, Tokyo'
-venueUrl: 'https://www.aspire.t.u-tokyo.ac.jp/'
+venue: 'Invited Talk, ASPIRE Computer Vision Workshop at Tokyo'
+venueUrl: 'https://research-p.com/event/2770'
 type: 'invited'
 coverImage: './2026-aspire-workshop-cover.svg'
 slides: 'https://speakerdeck.com/gatheluck/who-sets-the-questions-agenda-setting-through-workshops-in-the-age-of-ai'

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -60,12 +60,12 @@ const typeBadgeColors = {
                     </div>
                   )}
                   <div class={talk.data.coverImage ? 'flex-1 p-5' : 'flex-1'}>
-                    <div class="flex flex-wrap items-center gap-2">
+                    <div>
                       <h3 class="text-lg font-semibold text-gray-900 transition-colors duration-200 group-hover:text-primary-600 dark:text-gray-100 dark:group-hover:text-primary-400">
                         {talk.data.title}
                       </h3>
                       <span
-                        class={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${typeBadgeColors[talk.data.type as keyof typeof typeBadgeColors]}`}
+                        class={`mt-2 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${typeBadgeColors[talk.data.type as keyof typeof typeBadgeColors]}`}
                       >
                         {typeLabels[talk.data.type as keyof typeof typeLabels]}
                       </span>


### PR DESCRIPTION
 Description:
  ## Summary
  - Unified badge placement on Talks page to always display type badges below talk titles for better consistency
  - Added new talk: "Ascender: Accelerator of Scientific Development and Research" (CCCS 2022)
  - Added new talk: "Adversarial Examples 分野の動向: History and Trends of Dark Arts" (cvpaper.challenge 2019)
  - Added venue URLs to existing talks for improved accessibility

  ## Changes
  - `src/pages/talks.astro`: Modified badge container to remove `flex-wrap` and always display badges below titles with `mt-2` spacing
  - `src/content/talks/2022-ascender.mdx`: New talk entry with slides link
  - `src/content/talks/2019-adversarial.mdx`: New talk entry with slides link
  - `src/content/talks/2020-adversarial.mdx`: Added venueUrl field
  - `src/content/talks/2026-aspire-workshop.mdx`: Updated venue description and venueUrl